### PR TITLE
fixed issue #1. Pure unaldulterated cherrypick of #2 for the purpose of fixing #1 only.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,9 +11,9 @@ var presetMap = {
 // lineBreak Schemes
 var brPat = /<\s*br(?:[\s/]*|\s[^>]*)>/gi;
 var lineBreakSchemeMap = {
-    'unix': [/\n/g, '\n'],
-    'dos': [/\r\n/g, '\r\n'],
-    'mac': [/\r/g, '\r'],
+    'unix': [/(?:\r\n|\n|\r)/g, '\n'],
+    'dos': [/(?:\r\n|\n|\r)/g, '\r\n'],
+    'mac': [/(?:\r\n|\n|\r)/g, '\r'],
     'html': [brPat, '<br>'],
     'xhtml': [brPat, '<br/>']
 };
@@ -321,7 +321,7 @@ var linewrap = module.exports = function (start, stop, params) {
     // yet. We will try to get the value from the input string, and if failed, we
     // will throw an exception.
     if (!lineBreakPat) {
-        lineBreakPat = /\n/g;
+        lineBreakPat = /(?:\r\n|\n|\r)/g;
         lineBreakStr = '\n';
     }
 


### PR DESCRIPTION
- paragraph tests pass. 
- The fix for #1 is simply allowing arbitrary line breaks in the input, but outputting the requested type (Windows, Unix, Mac). Garbage in, Sanity out.

